### PR TITLE
Reformatting to DW style

### DIFF
--- a/.github/workflows/phpCS.yml
+++ b/.github/workflows/phpCS.yml
@@ -1,6 +1,6 @@
 name: PHP Code Style
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
     phpcs:

--- a/PageQuery.php
+++ b/PageQuery.php
@@ -53,7 +53,7 @@ class PageQuery
     final public function renderAsHtml(string $layout, $sorted_results, $opt, $count)
     {
         $this->snippet_cnt = $opt['snippet']['count'];
-        $render_type       = '_render_as_html_' . $layout;
+        $render_type       = 'renderAsHtml' . $layout;
         return $this->$render_type($sorted_results, $opt, $count);
     }
 
@@ -793,7 +793,7 @@ class PageQuery
      * @param int   $count => count of results
      * @return string => HTML rendered list
      */
-    protected function _render_as_html_table($sorted_results, $opt, $count): string
+    protected function renderAsHtmltable($sorted_results, $opt, $count): string
     {
         $ratios           = array(.80, 1.3, 1.17, 1.1, 1.03, .96, .90);   // height ratios: link, h1, h2, h3, h4, h5, h6
         $render           = '';
@@ -1082,7 +1082,7 @@ class PageQuery
      *
      * @return string HTML rendered list
      */
-    protected function _render_as_html_column(array $sorted_results, array $opt, int $count): string
+    protected function renderAsHtmlcolumn(array $sorted_results, array $opt, int $count): string
     {
         $prev_was_heading = false;
         $cont_level       = 1;

--- a/PageQuery.php
+++ b/PageQuery.php
@@ -445,6 +445,7 @@ class PageQuery
      */
     final public function pageSearch(string $query): array
     {
+        $highlight = [];
         return array_keys(ft_pageSearch($query, $highlight));
     }
 
@@ -977,8 +978,9 @@ class PageQuery
         bool $raw = false
     ): string {
         $id = (strpos($id, ':') === false) ? ':' . $id : $id;   // : needed for root pages (root level)
-
-        $link   = html_wikilink($id, $display);
+        // TODO find out if this is an API change in DW
+        //        $link   = html_wikilink($id, $display);
+        $link   = html_wikilink($id);
         $type   = $opt['snippet']['type'];
         $inline = '';
         $after  = '';

--- a/PageQuery.php
+++ b/PageQuery.php
@@ -36,7 +36,7 @@ class PageQuery
      * @param string $error
      * @return string
      */
-    final public function render_as_empty($query, $error = ''): string
+    final public function renderAsEmpty($query, $error = ''): string
     {
         $render = '<div class="pagequery no-border">' . DOKU_LF;
         $render .= '<p class="no-results"><span>pagequery</span>' . sprintf(
@@ -50,7 +50,7 @@ class PageQuery
         return $render;
     }
 
-    final public function render_as_html(string $layout, $sorted_results, $opt, $count)
+    final public function renderAsHtml(string $layout, $sorted_results, $opt, $count)
     {
         $this->snippet_cnt = $opt['snippet']['count'];
         $render_type       = '_render_as_html_' . $layout;

--- a/_test/general.test.php
+++ b/_test/general.test.php
@@ -21,14 +21,16 @@
  * @group plugin_pagequery
  * @group plugins
  */
-class general_plugin_pagequery_test extends DokuWikiTest {
+class general_plugin_pagequery_test extends DokuWikiTest
+{
 
     protected $pluginsEnabled = array('pagequery');
 
     /**
      * Simple test to make sure the plugin.info.txt is in correct format
      */
-    public function test_plugininfo(): void {
+    public function test_plugininfo(): void
+    {
         $file = __DIR__ . '/../plugin.info.txt';
         $this->assertFileExists($file);
 
@@ -52,10 +54,13 @@ class general_plugin_pagequery_test extends DokuWikiTest {
     /**
      * test if plugin is loaded.
      */
-    public function test_plugin_pagequery_isloaded() {
+    public function test_plugin_pagequery_isloaded()
+    {
         global $plugin_controller;
         $this->assertContains(
-            'pagequery', $plugin_controller->getList(), "pagequery plugin is loaded"
+            'pagequery',
+            $plugin_controller->getList(),
+            "pagequery plugin is loaded"
         );
     }
 }

--- a/action.php
+++ b/action.php
@@ -4,16 +4,18 @@
  *
  * @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
-class action_plugin_pagequery extends DokuWiki_Action_Plugin {
+class action_plugin_pagequery extends DokuWiki_Action_Plugin
+{
 
-    public function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insertButton', array ());
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insertButton', array());
         $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, 'purgecache');
     }
 
-
-    public function insertButton(Doku_Event $event, $param) {
-        $event->data[] = array (
+    public function insertButton(Doku_Event $event, $param)
+    {
+        $event->data[] = array(
             'type'  => 'dialog',
             'title' => $this->getLang('pagequery'),
             'icon'  => '../../plugins/pagequery/images/pagequery.png',
@@ -22,16 +24,16 @@ class action_plugin_pagequery extends DokuWiki_Action_Plugin {
         );
     }
 
-
-    public function pqCheatsheet() {
+    public function pqCheatsheet()
+    {
         $list = file(DOKU_PLUGIN . 'pagequery/res/toolbar', FILE_IGNORE_NEW_LINES);
         $text = '<div id="pq-dialog" title="PageQuery Cheatsheet" style="font-size:75%;">' . PHP_EOL;
-        foreach($list as $line) {
-            $tab = '';
+        foreach ($list as $line) {
+            $tab  = '';
             $item = explode("\t", $line, 2);
             if (substr($item[0], 0, 1) === '-') {
                 $item[0] = substr($item[0], 2);
-                $tab = "&nbsp;&nbsp;&nbsp;&nbsp;";
+                $tab     = "&nbsp;&nbsp;&nbsp;&nbsp;";
             }
             $text .= $tab . '<b>' . $item[0] . '</b>&nbsp; ' . $item[1] . '</br>' . PHP_EOL;
         }
@@ -40,44 +42,56 @@ class action_plugin_pagequery extends DokuWiki_Action_Plugin {
         return $text;
     }
 
-
     /**
      * Check for pages changes and eventually purge cache.
      *
-     * @author Samuele Tognini <samuele@samuele.netsons.org>
-     *
      * @param Doku_Event $event
      * @param mixed      $param not defined
+     * @author Samuele Tognini <samuele@samuele.netsons.org>
+     *
      */
-    public function purgecache(Doku_Event $event, $param) {
+    public function purgecache(Doku_Event $event, $param)
+    {
         global $ID;
         global $conf;
         /** @var cache_parser $cache */
         $cache = $event->data;
 
-        if(!isset($cache->page)) return;
+        if (!isset($cache->page)) {
+            return;
+        }
         //purge only xhtml cache
-        if($cache->mode !== "xhtml") return;
+        if ($cache->mode !== "xhtml") {
+            return;
+        }
         //Check if it is an pagequery page
-        if(!p_get_metadata($ID, 'pagequery')) return;
+        if (!p_get_metadata($ID, 'pagequery')) {
+            return;
+        }
         $aclcache = $this->getConf('aclcache');
-        if($conf['useacl']) {
+        if ($conf['useacl']) {
             $newkey = false;
-            if($aclcache === 'user') {
+            if ($aclcache === 'user') {
                 //Cache per user
-                if($_SERVER['REMOTE_USER']) $newkey = $_SERVER['REMOTE_USER'];
-            } else if($aclcache === 'groups') {
-                //Cache per groups
-                global $INFO;
-                if($INFO['userinfo']['grps']) $newkey = implode('#', $INFO['userinfo']['grps']);
+                if ($_SERVER['REMOTE_USER']) {
+                    $newkey = $_SERVER['REMOTE_USER'];
+                }
+            } else {
+                if ($aclcache === 'groups') {
+                    //Cache per groups
+                    global $INFO;
+                    if ($INFO['userinfo']['grps']) {
+                        $newkey = implode('#', $INFO['userinfo']['grps']);
+                    }
+                }
             }
-            if($newkey) {
-                $cache->key .= "#".$newkey;
+            if ($newkey) {
+                $cache->key   .= "#" . $newkey;
                 $cache->cache = getCacheName($cache->key, $cache->ext);
             }
         }
         //Check if a page is more recent than purgefile.
-        if(@filemtime($cache->cache) < @filemtime($conf['cachedir'].'/purgefile')) {
+        if (@filemtime($cache->cache) < @filemtime($conf['cachedir'] . '/purgefile')) {
             $event->preventDefault();
             $event->stopPropagation();
             $event->result = false;

--- a/syntax.php
+++ b/syntax.php
@@ -13,22 +13,22 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
 
     const MAX_COLS = 12;
 
-    public function getType()
+    public function getType(): string
     {
         return 'substition';
     }
 
-    public function getPType()
+    public function getPType(): string
     {
         return 'block';
     }
 
-    public function getSort()
+    public function getSort(): int
     {
         return 98;
     }
 
-    public function connectTo($mode)
+    public function connectTo($mode): void
     {
         // this regex allows multi-line syntax for easier composition/reading
         $this->Lexer->addSpecialPattern('\{\{pagequery>(?m).*?(?-m)\}\}', $mode, 'plugin_pagequery');
@@ -44,7 +44,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
      *
      * @link https://www.dokuwiki.org/plugin:pagequery See PageQuery page for full details
      */
-    public function handle($match, $state, $pos, Doku_Handler $handler)
+    public function handle($match, $state, $pos, Doku_Handler $handler): array
     {
         $opt    = array();
         $match  = substr($match, 12, -2); // strip markup "{{pagequery>...}}"
@@ -197,7 +197,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
                         default:
                             $opt['display'] = $value;
                     }
-                    if (preg_match('/\{(title|heading|firstheading)\}/', $value)) {
+                    if (preg_match('/{(title|heading|firstheading)}/', $value)) {
                         $opt['nstitle'] = true;
                     }
                     break;
@@ -224,15 +224,15 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
      * @param string $delim
      * @return array
      */
-    private function keyvalue($str, $delim = ':')
+    private function keyvalue(string $str, string $delim = ':'): array
     {
         $parts = explode($delim, $str);
-        $key   = isset($parts[0]) ? $parts[0] : '';
-        $value = isset($parts[1]) ? $parts[1] : '';
+        $key   = $parts[0] ?? '';
+        $value = $parts[1] ?? '';
         return array($key, $value);
     }
 
-    public function render($mode, Doku_Renderer $renderer, $opt)
+    public function render($format, Doku_Renderer $renderer, $data): bool
     {
         $incl_ns    = array();
         $excl_ns    = array();
@@ -248,12 +248,12 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
         require_once DOKU_PLUGIN . 'pagequery/PageQuery.php';
         $pq = new PageQuery($lang);
 
-        $query = $opt['query'];
+        $query = $data['query'];
 
-        if ($mode === 'xhtml') {
+        if ($format === 'xhtml') {
             // first get a raw list of matching results
 
-            if ($opt['fulltext']) {
+            if ($data['fulltext']) {
                 // full text searching (Dokuwiki style)
                 $results = $pq->pageSearch($query);
             } else {
@@ -261,7 +261,7 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
 
                 // fullregex option considers entire query to be a regex
                 // over the whole page id, incl. namespace
-                if (!$opt['fullregex']) {
+                if (!$data['fullregex']) {
                     list($query, $incl_ns, $excl_ns) = $pq->parseNamespaceQuery($query);
                 }
 
@@ -270,20 +270,21 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
                     $query = '.*';
                 }
                 // search by page name or path only
-                $results = $pq->pageLookup($query, $opt['fullregex'], $incl_ns, $excl_ns);
+                $results = $pq->pageLookup($query, $data['fullregex'], $incl_ns, $excl_ns);
             }
-            $results = $pq->validatePages($results, $opt['hidestart'], $opt['maxns']);
+            $results = $pq->validatePages($results, $data['hidestart'], $data['maxns']);
 
             $no_result = false;
-            if ($results === false) {
+            $sort_array = [];
+            if ($results == false) {
                 $no_result = true;
                 $message   = $this->getLang('regex_error');
             } elseif (!empty($results)) {
                 // prepare the necessary sorting arrays, as per users options
-                list($sort_array, $sort_opts, $group_opts) = $pq->buildSortingArray($results, $opt);
+                list($sort_array, $sort_opts, $group_opts) = $pq->buildSortingArray($results, $data);
 
                 // meta data filtering of the list is next
-                $sort_array = $pq->filterMetadata($sort_array, $opt['filter']);
+                $sort_array = $pq->filterMetadata($sort_array, $data['filter']);
                 if (empty($sort_array)) {
                     $no_result = true;
                     $message   = $this->getLang("empty_filter");
@@ -298,8 +299,8 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
                 $pq->msort($sort_array, $sort_opts);
 
                 // limit the result list length if required; this can only be done after sorting!
-                if ($opt['limit'] > 0) {
-                    $sort_array = array_slice($sort_array, 0, $opt['limit']);
+                if ($data['limit'] > 0) {
+                    $sort_array = array_slice($sort_array, 0, $data['limit']);
                 }
 
                 // do a link count BEFORE grouping (don't want to count headers...)
@@ -307,22 +308,22 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
 
                 // and finally the grouping
                 $keys = array('name', 'id', 'title', 'abstract', 'display');
-                if (!$opt['group']) {
+                if (!$data['group']) {
                     $group_opts = array();
                 }
                 $sorted_results = $pq->mgroup($sort_array, $keys, $group_opts);
 
                 // and out to the page
-                $renderer->doc .= $pq->renderAsHtml($opt['layout'], $sorted_results, $opt, $count);
+                $renderer->doc .= $pq->renderAsHtml($data['layout'], $sorted_results, $data, $count);
                 // no results...
             } else {
-                if (!$opt['hidemsg']) {
+                if (!$data['hidemsg']) {
                     $renderer->doc .= $pq->renderAsEmpty($query, $message);
                 }
             }
             return true;
         } else {
-            if ($mode === 'metadata') {
+            if ($format === 'metadata') {
                 // this is a pagequery page needing PARSER_CACHE_USE event trigger;
                 $renderer->meta['pagequery'] = true;
                 unset($renderer->persistent['pagequery']);

--- a/syntax.php
+++ b/syntax.php
@@ -1,37 +1,38 @@
 <?php
+
 /**
  * PageQuery Plugin: search for and list pages, sorted/grouped by name, date, creator, etc
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Symon Bent <hendrybadao@gmail.com>
  *
- * @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+ * @phpcs      :disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
-class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
+class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
+{
 
     const MAX_COLS = 12;
 
-
-    public function getType() {
+    public function getType()
+    {
         return 'substition';
     }
 
-
-    public function getPType() {
+    public function getPType()
+    {
         return 'block';
     }
 
-
-    public function getSort() {
+    public function getSort()
+    {
         return 98;
     }
 
-
-    public function connectTo($mode) {
+    public function connectTo($mode)
+    {
         // this regex allows multi-line syntax for easier composition/reading
         $this->Lexer->addSpecialPattern('\{\{pagequery>(?m).*?(?-m)\}\}', $mode, 'plugin_pagequery');
     }
-
 
     /**
      * Parses all the pagequery options:
@@ -43,10 +44,10 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
      *
      * @link https://www.dokuwiki.org/plugin:pagequery See PageQuery page for full details
      */
-    public function handle($match, $state, $pos, Doku_Handler $handler) {
-
-        $opt = array();
-        $match = substr($match, 12, -2); // strip markup "{{pagequery>...}}"
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
+        $opt    = array();
+        $match  = substr($match, 12, -2); // strip markup "{{pagequery>...}}"
         $params = explode(';', $match);
         // remove any pre/trailing spaces due to multi-line syntax
         $params = array_map('trim', $params);
@@ -163,12 +164,12 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                         break;
                     } else {
                         $options = explode(',', $value);
-                        $type = ( ! empty($options[0])) ? $options[0] : $opt['snippet']['type'];
-                        $count = ( ! empty($options[1])) ? $options[1] : $opt['snippet']['count'];
-                        $extent = ( ! empty($options[2])) ? $options[2] : $opt['snippet']['extent'];
+                        $type    = (!empty($options[0])) ? $options[0] : $opt['snippet']['type'];
+                        $count   = (!empty($options[1])) ? $options[1] : $opt['snippet']['count'];
+                        $extent  = (!empty($options[2])) ? $options[2] : $opt['snippet']['extent'];
 
                         $valid = array('none', 'tooltip', 'inline', 'plain', 'quoted');
-                        if ( ! in_array($type, $valid)) {
+                        if (!in_array($type, $valid)) {
                             $type = $default;  // empty snippet type => tooltip
                         }
                         $opt['snippet'] = array('type' => $type, 'count' => $count, 'extent' => $extent);
@@ -201,13 +202,13 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                     }
                     break;
                 case 'layout':
-                    if ( ! in_array($value, array('table', 'column'))) {
+                    if (!in_array($value, array('table', 'column'))) {
                         $value = 'table';
                     }
                     $opt['layout'] = $value;
                     break;
                 case 'fontsize':
-                    if ( ! empty($value)) {
+                    if (!empty($value)) {
                         $opt['fontsize'] = $value;
                     }
                     break;
@@ -216,13 +217,28 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         return $opt;
     }
 
+    /**
+     * Split a string into key => value parts.
+     *
+     * @param string $str
+     * @param string $delim
+     * @return array
+     */
+    private function keyvalue($str, $delim = ':')
+    {
+        $parts = explode($delim, $str);
+        $key   = isset($parts[0]) ? $parts[0] : '';
+        $value = isset($parts[1]) ? $parts[1] : '';
+        return array($key, $value);
+    }
 
-    public function render($mode, Doku_Renderer $renderer, $opt) {
-        $incl_ns = array();
-        $excl_ns = array();
-        $sort_opts = array();
+    public function render($mode, Doku_Renderer $renderer, $opt)
+    {
+        $incl_ns    = array();
+        $excl_ns    = array();
+        $sort_opts  = array();
         $group_opts = array();
-        $message = '';
+        $message    = '';
 
         $lang = array(
             'jump_section' => $this->getLang('jump_section'),
@@ -235,19 +251,17 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
         $query = $opt['query'];
 
         if ($mode === 'xhtml') {
-
             // first get a raw list of matching results
 
             if ($opt['fulltext']) {
                 // full text searching (Dokuwiki style)
                 $results = $pq->pageSearch($query);
-
             } else {
                 // page id searching (i.e. namespace and name, faster)
 
                 // fullregex option considers entire query to be a regex
                 // over the whole page id, incl. namespace
-                if ( ! $opt['fullregex']) {
+                if (!$opt['fullregex']) {
                     list($query, $incl_ns, $excl_ns) = $pq->parseNamespaceQuery($query);
                 }
 
@@ -263,10 +277,8 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
             $no_result = false;
             if ($results === false) {
                 $no_result = true;
-                $message = $this->getLang('regex_error');
-
-            } elseif ( ! empty($results)) {
-
+                $message   = $this->getLang('regex_error');
+            } elseif (!empty($results)) {
                 // prepare the necessary sorting arrays, as per users options
                 list($sort_array, $sort_opts, $group_opts) = $pq->buildSortingArray($results, $opt);
 
@@ -274,15 +286,14 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
                 $sort_array = $pq->filterMetadata($sort_array, $opt['filter']);
                 if (empty($sort_array)) {
                     $no_result = true;
-                    $message = $this->getLang("empty_filter");
+                    $message   = $this->getLang("empty_filter");
                 }
             } else {
                 $no_result = true;
             }
 
             // successful search...
-            if ( ! $no_result) {
-
+            if (!$no_result) {
                 // now do the sorting
                 $pq->msort($sort_array, $sort_opts);
 
@@ -296,42 +307,30 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin {
 
                 // and finally the grouping
                 $keys = array('name', 'id', 'title', 'abstract', 'display');
-                if ( ! $opt['group']) $group_opts = array();
+                if (!$opt['group']) {
+                    $group_opts = array();
+                }
                 $sorted_results = $pq->mgroup($sort_array, $keys, $group_opts);
 
                 // and out to the page
                 $renderer->doc .= $pq->render_as_html($opt['layout'], $sorted_results, $opt, $count);
-
-            // no results...
+                // no results...
             } else {
-                if ( ! $opt['hidemsg']) {
+                if (!$opt['hidemsg']) {
                     $renderer->doc .= $pq->render_as_empty($query, $message);
                 }
             }
             return true;
-        } else if ($mode === 'metadata' ) {
-            // this is a pagequery page needing PARSER_CACHE_USE event trigger;
-            $renderer->meta['pagequery'] = TRUE;
-            unset($renderer->persistent['pagequery']);
-            return true;
         } else {
-            return false;
+            if ($mode === 'metadata') {
+                // this is a pagequery page needing PARSER_CACHE_USE event trigger;
+                $renderer->meta['pagequery'] = true;
+                unset($renderer->persistent['pagequery']);
+                return true;
+            } else {
+                return false;
+            }
         }
-    }
-
-
-    /**
-     * Split a string into key => value parts.
-     *
-     * @param string $str
-     * @param string $delim
-     * @return array
-     */
-    private function keyvalue($str, $delim = ':') {
-        $parts = explode($delim, $str);
-        $key = isset($parts[0]) ? $parts[0] : '';
-        $value = isset($parts[1]) ? $parts[1] : '';
-        return array($key, $value);
     }
 }
 

--- a/syntax.php
+++ b/syntax.php
@@ -313,11 +313,11 @@ class syntax_plugin_pagequery extends DokuWiki_Syntax_Plugin
                 $sorted_results = $pq->mgroup($sort_array, $keys, $group_opts);
 
                 // and out to the page
-                $renderer->doc .= $pq->render_as_html($opt['layout'], $sorted_results, $opt, $count);
+                $renderer->doc .= $pq->renderAsHtml($opt['layout'], $sorted_results, $opt, $count);
                 // no results...
             } else {
                 if (!$opt['hidemsg']) {
-                    $renderer->doc .= $pq->render_as_empty($query, $message);
+                    $renderer->doc .= $pq->renderAsEmpty($query, $message);
                 }
             }
             return true;


### PR DESCRIPTION
style errors:

- [x] Error: Method name "PageQuery::render_as_empty" is not in camel caps format
- [x] Error: Method name "PageQuery::render_as_html" is not in camel caps format
- [x] Error: Method name "PageQuery::_render_as_html_table" is not in camel caps format
- [x] Error: Method name "PageQuery::_render_as_html_column" is not in camel caps format
- [x] Error: Method name "_render_as_html_table" must not be prefixed with an underscore to indicate visibility
- [x] Error: Method name "_render_as_html_column" must not be prefixed with an underscore to indicate visibility