### PR TITLE
github issue 10: fix the broken html layout 2/2

### DIFF
--- a/PageQuery.php
+++ b/PageQuery.php
@@ -866,7 +866,7 @@ class PageQuery
             //    1) we are at the start,
             //    2) last item was not a heading
             //    3) OR if the user turned grouping on
-            if ($can_start_col === true && $prev_was_heading === false
+            if ($can_start_col === true && $prev_was_heading === true
                     || $can_indent === true && $prev_was_heading === true) {
                 $jump_tip = sprintf($this->lang['jump_section'], $heading);
                 // close the previous column if necessary; also adds a 'jump to anchor'

--- a/PageQuery.php
+++ b/PageQuery.php
@@ -862,7 +862,10 @@ class PageQuery
                 $indent_style = 'margin-left:' . $indent * 10 . 'px;';
             }
 
-            // Begin new column if: 1) we are at the start, 2) last item was not a heading 3) OR if the user turned grouping on
+            // Begin new column if:
+            //    1) we are at the start,
+            //    2) last item was not a heading
+            //    3) OR if the user turned grouping on
             if ($can_start_col === true && $prev_was_heading === false
                     || $can_indent === true && $prev_was_heading === true) {
                 $jump_tip = sprintf($this->lang['jump_section'], $heading);

--- a/PageQuery.php
+++ b/PageQuery.php
@@ -862,8 +862,9 @@ class PageQuery
                 $indent_style = 'margin-left:' . $indent * 10 . 'px;';
             }
 
-            // Begin new column if: 1) we are at the start, 2) last item was not a heading or 3) if there is no grouping
-            if ($can_start_col && !$prev_was_heading) {
+            // Begin new column if: 1) we are at the start, 2) last item was not a heading 3) OR if the user turned grouping on
+            if ($can_start_col === true && $prev_was_heading === false
+                    || $can_indent === true && $prev_was_heading === true) {
                 $jump_tip = sprintf($this->lang['jump_section'], $heading);
                 // close the previous column if necessary; also adds a 'jump to anchor'
                 $col_close     = (!$is_heading) ? '<a title="' . $jump_tip . '" href="#' . $top_id . '">'

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    pagequery
 author  Mark C. Prins, previously Symon Bent
 email   mprins@users.sf.net
-date    2023-01-12
+date    2023-04-20
 name    PageQuery Plugin
 desc    Search for (fulltext) and list wiki pages, sorted and optionally grouped by name, date, creator, abc, etc. in columns. Insert the pagequery markup wherever you want your list to appear.  E.g.{{pagequery>[query;fulltext;sort=key:direction,key2:direction;group;limit=??;cols=?;inwords;proper]}} [..] = optional
 url     https://www.dokuwiki.org/plugin:pagequery


### PR DESCRIPTION
It turns out that dokuwiki caches plugins. I use the [stale](https://dokuwiki.org/plugin:stale) plugin to clear the cache.