### PR TITLE
Fix: Plugin crashes when trying to convert empty date-strings to a date

### DIFF
--- a/PageQuery.php
+++ b/PageQuery.php
@@ -266,7 +266,7 @@ class PageQuery
                         $value = $meta['date']['created'];
                     }
                     if (!is_null($value)) {
-                        if (strpos($key, 'date') !== false) {
+                        if (strpos($key, 'date') !== false && $value != '') {
                             $value = utf8_encode(strftime($opt['dformat'], $value));
                         }
                         $display = str_replace($match[0], $value, $display);


### PR DESCRIPTION
A pagequery like this crashed our wiki

```
{{pagequery>@:groups:qport:private:laborbuch: .+;sort=pagedate:desc;display={pagedate} - {title};bullet=square;hidemsg}}
```

The pagequery on "pagedate" caused `strftime` to get invoked. But the passed argument to `strftime` was an empty string, which made the wiki crash. This PR checks, if $value is an empty string and if so, skips `strftime`