### PR TITLE
code fixes to prevent php warnings

### DIFF
--- a/PageQuery.php
+++ b/PageQuery.php
@@ -1,6 +1,7 @@
 <?php
 
 use dokuwiki\Utf8\PhpString;
+use dokuwiki\File\PageResolver;
 
 class PageQuery
 {
@@ -76,9 +77,11 @@ class PageQuery
         } else {
             foreach ($tokens as $token) {
                 if (preg_match('/^(?:\^|-ns:)(.+)$/u', $token, $matches)) {
-                    $excl_ns[] = resolve_id($cur_ns, $matches[1]);  // also resolve relative and parent ns
+                   $resolver = new PageResolver($cur_ns);
+                   $excl_ns[] = resolve_id($cur_ns, $matches[1]);
                 } elseif (preg_match('/^(?:@|ns:)(.+)$/u', $token, $matches)) {
-                    $incl_ns[] = resolve_id($cur_ns, $matches[1]);
+                   $resolver = new PageResolver($cur_ns);
+                   $incl_ns[] = $resolver->resolveId($matches[1]);
                 } else {
                     $page_qry .= ' ' . $token;
                 }
@@ -356,7 +359,7 @@ class PageQuery
             if ($group_by !== self::MGROUP_NONE) {
                 $group_opts['key'][$idx]     = $key;
                 $group_opts['type'][$idx]    = $group_by;
-                $group_opts['dformat'][$idx] = $wformat[$key];
+                $group_opts['dformat'][$idx] = $wformat[$key] ?? '';
                 $idx++;
             }
         }
@@ -837,7 +840,12 @@ class PageQuery
 
         // now render the pagequery list
         foreach ($sorted_results as $line) {
-            [$level, $name, $id, $_, $abstract, $display] = $line;
+           $level = $line[0] ?? '';
+           $name = $line[1] ?? '';
+           $id = $line[2] ?? '';
+           $_ = $line[3] ?? '';
+           $abstract = $line[4] ?? '';
+           $display = $line[5] ?? '';
 
             $heading    = '';
             $is_heading = ($level > 0);


### PR DESCRIPTION
Makes code changes to fix the following:

1.  Replace calls to resolve_id with dokuwiki's File\Resolver. This fixes the deprecation warnings in the dokuwiki logs.
2. Check for NULL values when rendering the pagequery list

